### PR TITLE
pkgs: nixpkgs weekly pull 20231214

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -133,6 +133,9 @@
                 };
 
                 pyqt5 = pkgs.${python}.pkgs.pyqt5.override {
+                  # FIX sip and pyqt5_sip compatibility. See: https://github.com/NixOS/nixpkgs/issues/273561
+                  # Remove this fix in NixOS 24.05.
+                  pyqt5_sip = pkgs.${python}.pkgs.callPackage ./pkgs/qgis/pyqt5-sip.nix { };
                   withLocation = true;
                 };
 

--- a/pkgs/gdal/default.nix
+++ b/pkgs/gdal/default.nix
@@ -239,6 +239,9 @@ stdenv.mkDerivation (finalAttrs: {
     # fixed and renamed in 3.8.0RC1
     # https://github.com/OSGeo/gdal/commit/c8b471ca1e6318866ff668d2b57bb6f076e3ae29
     "test_visoss_6"
+    # failing with PROJ 9.3.1
+    # https://github.com/OSGeo/gdal/issues/8908
+    "test_osr_esri_28"
   ] ++ lib.optionals (!stdenv.isx86_64) [
     # likely precision-related expecting x87 behaviour
     "test_jp2openjpeg_22"

--- a/pkgs/geos/default.nix
+++ b/pkgs/geos/default.nix
@@ -1,7 +1,6 @@
 { lib
 , stdenv
 , callPackage
-, fetchpatch
 , fetchurl
 , testers
 
@@ -10,22 +9,12 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "geos";
-  version = "3.11.2";
+  version = "3.12.1";
 
   src = fetchurl {
     url = "https://download.osgeo.org/geos/${finalAttrs.pname}-${finalAttrs.version}.tar.bz2";
-    hash = "sha256-sfB3ZpSBxaPmKv/EnpbrBvKBmHpdNv2rIlIX5bgl5Mw=";
+    hash = "sha256-1up+SSIktRGT6CRP4+wXxNRNB3fzwyyk+xcRQFSaDQM=";
   };
-
-  patches = [
-    # Pull upstream fix of `gcc-13` build failure:
-    #   https://github.com/libgeos/geos/pull/805
-    (fetchpatch {
-      name = "gcc-13.patch";
-      url = "https://github.com/libgeos/geos/commit/bea3188be44075034fd349f5bb117c943bdb7fb1.patch";
-      hash = "sha256-dQT3Hf9YJchgjon/r46TLIXXbE6C0ZnewyvfYJea4jM=";
-    })
-  ];
 
   nativeBuildInputs = [ cmake ];
 
@@ -40,8 +29,9 @@ stdenv.mkDerivation (finalAttrs: {
     description = "C/C++ library for computational geometry with a focus on algorithms used in geographic information systems (GIS) software";
     homepage = "https://libgeos.org";
     license = licenses.lgpl21Only;
+    mainProgram = "geosop";
     maintainers = teams.geospatial.members;
     pkgConfigModules = [ "geos" ];
-    mainProgram = "geosop";
+    changelog = "https://github.com/libgeos/geos/releases/tag/${finalAttrs.finalPackage.version}";
   };
 })

--- a/pkgs/proj/default.nix
+++ b/pkgs/proj/default.nix
@@ -17,13 +17,13 @@
 
 stdenv.mkDerivation (finalAttrs: rec {
   pname = "proj";
-  version = "9.3.0";
+  version = "9.3.1";
 
   src = fetchFromGitHub {
     owner = "OSGeo";
     repo = "PROJ";
     rev = version;
-    hash = "sha256-M1KUXzht4qIjPfHxvzPr7XUnisMwtbegKp18XQjNYHg=";
+    hash = "sha256-M8Zgy5xnmZu7mzxXXGqaIfe7o7iMf/1sOJVOBsTvtdQ=";
   };
 
   patches = [

--- a/pkgs/qgis/pyqt5-sip.nix
+++ b/pkgs/qgis/pyqt5-sip.nix
@@ -1,0 +1,31 @@
+# FIX sip and pyqt5_sip compatibility. See: https://github.com/NixOS/nixpkgs/issues/273561
+# Remove this fix in NixOS 24.05.
+
+{ lib
+, buildPythonPackage
+, fetchPypi
+}:
+
+buildPythonPackage rec {
+  pname = "pyqt5-sip";
+  version = "12.13.0";
+
+  src = fetchPypi {
+    pname = "PyQt5_sip";
+    inherit version;
+    hash = "sha256-fzIdr4S5ydvKYbgOHvN72v/A6TMS7a4s19oluVOXHZE=";
+  };
+
+  # There is no test code and the check phase fails with:
+  # > error: could not create 'PyQt5/sip.cpython-38-x86_64-linux-gnu.so': No such file or directory
+  doCheck = false;
+  pythonImportsCheck = ["PyQt5.sip"];
+
+  meta = with lib; {
+    description = "Python bindings for Qt5";
+    homepage    = "https://www.riverbankcomputing.com/software/sip/";
+    license     = licenses.gpl3Only;
+    platforms   = platforms.mesaPlatforms;
+    maintainers = with maintainers; [ sander ];
+  };
+}


### PR DESCRIPTION
- pkgs(qgis,qgis-ltr): fix sip and pyqt5_sip compatibility
- pkgs(geos): 3.11.2 -> 3.12.1
- pkgs(proj): 9.3.0 -> 9.3.1
- pkgs(gdal): disable test failing with PROJ 9.3.1
