### PR TITLE
pkgs: nixpkgs weekly pull 20240119

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -102,7 +102,7 @@
               };
 
               pdal = pkgs.callPackage ./pkgs/pdal {
-                inherit gdal libgeotiff;
+                inherit gdal libgeotiff tiledb;
               };
 
               proj = pkgs.callPackage ./pkgs/proj { };

--- a/flake.nix
+++ b/flake.nix
@@ -171,8 +171,9 @@
               postgresql-packages = forAllPostgresqlVersions (postgresql: rec {
 
                 postgis = pkgs.callPackage ./pkgs/postgis/postgis.nix {
-                  inherit gdal geos proj;
+                  inherit geos proj;
 
+                  gdalMinimal = gdal-minimal;
                   postgresql = pkgs.${postgresql};
                 };
 

--- a/pkgs/gdal/default.nix
+++ b/pkgs/gdal/default.nix
@@ -76,13 +76,13 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "gdal";
-  version = "3.8.2";
+  version = "3.8.3";
 
   src = fetchFromGitHub {
     owner = "OSGeo";
     repo = "gdal";
     rev = "v${finalAttrs.version}";
-    hash = "sha256-R21zRjEvJO+97yXJDvzDJryQ7ps9uEN62DZ0GCxdoFk=";
+    hash = "sha256-GYBGGZ2bobVYElO0WJrsQzLMdNR5AfQwgdjBtPeGH1g=";
   };
 
   nativeBuildInputs = [

--- a/pkgs/geonixcli/templates/override/overrides.nix
+++ b/pkgs/geonixcli/templates/override/overrides.nix
@@ -139,7 +139,7 @@ rec {
 
     # >>> CUSTOMIZE HERE
 
-  })).override { inherit gdal libgeotiff; };
+  })).override { inherit gdal libgeotiff tiledb; };
 
 
   #####################################################################

--- a/pkgs/geonixcli/templates/override/overrides.nix
+++ b/pkgs/geonixcli/templates/override/overrides.nix
@@ -250,7 +250,7 @@ rec {
 
     # >>> CUSTOMIZE HERE
 
-  })).override { inherit gdal geos proj; };
+  })).override { inherit geos proj; gdalMinimal = gdal-minimal; };
 
   }; ### POSTGRESQL PACKAGES
 

--- a/pkgs/pdal/default.nix
+++ b/pkgs/pdal/default.nix
@@ -2,6 +2,7 @@
 , stdenv
 , callPackage
 , fetchFromGitHub
+, fetchpatch
 , testers
 
 , enableE57 ? lib.meta.availableOn stdenv.hostPlatform libe57format
@@ -18,6 +19,7 @@
 , openscenegraph
 , pkg-config
 , postgresql
+, proj
 , tiledb
 , xercesc
 , zlib
@@ -26,14 +28,23 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "pdal";
-  version = "2.5.6";
+  version = "2.6.2";
 
   src = fetchFromGitHub {
     owner = "PDAL";
     repo = "PDAL";
     rev = finalAttrs.version;
-    sha256 = "sha256-JKwa89c05EfZ/FxOkj8lYmw0o2EgSqafRDIV2mTpZ5E=";
+    sha256 = "sha256-bYTSmrel8MLza+OxO+aOSsnkahjjqRRqUiVwAk23Gxk=";
   };
+
+  patches = [
+    # Fix running tests
+    # https://github.com/PDAL/PDAL/issues/4280
+    (fetchpatch {
+      url = "https://patch-diff.githubusercontent.com/raw/PDAL/PDAL/pull/4291.patch";
+      sha256 = "sha256-jFS+trwMRBfm+MpT0CcuD/hdYmfyuQj2zyoe06B6G9U=";
+    })
+  ];
 
   nativeBuildInputs = [
     cmake
@@ -50,6 +61,7 @@ stdenv.mkDerivation (finalAttrs: {
     libxml2
     openscenegraph
     postgresql
+    proj
     tiledb
     xercesc
     zlib
@@ -63,6 +75,7 @@ stdenv.mkDerivation (finalAttrs: {
     "-DBUILD_PLUGIN_HDF=ON"
     "-DBUILD_PLUGIN_PGPOINTCLOUD=ON"
     "-DBUILD_PLUGIN_TILEDB=ON"
+    "-DWITH_COMPLETION=ON"
     "-DWITH_TESTS=ON"
     "-DBUILD_PGPOINTCLOUD_TESTS=OFF"
 
@@ -92,6 +105,7 @@ stdenv.mkDerivation (finalAttrs: {
     "pdal_io_tiledb_time_writer_test"
     "pdal_io_tiledb_time_reader_test"
     "pdal_io_tiledb_bit_fields_test"
+    "pdal_io_tiledb_utils_test"
     "pdal_io_e57_read_test"
     "pdal_io_e57_write_test"
     "pdal_io_stac_reader_test"

--- a/pkgs/postgis/postgis.nix
+++ b/pkgs/postgis/postgis.nix
@@ -5,7 +5,7 @@
 , postgresql
 , geos
 , proj
-, gdal
+, gdalMinimal
 , json_c
 , pkg-config
 , file
@@ -14,6 +14,10 @@
 , pcre2
 , nixosTests
 }:
+
+let
+  gdal = gdalMinimal;
+in
 stdenv.mkDerivation rec {
   pname = "postgis";
   version = "3.4.1";

--- a/pkgs/proj/default.nix
+++ b/pkgs/proj/default.nix
@@ -15,14 +15,14 @@
 , cacert
 }:
 
-stdenv.mkDerivation (finalAttrs: rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "proj";
   version = "9.3.1";
 
   src = fetchFromGitHub {
     owner = "OSGeo";
     repo = "PROJ";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-M8Zgy5xnmZu7mzxXXGqaIfe7o7iMf/1sOJVOBsTvtdQ=";
   };
 
@@ -64,7 +64,7 @@ stdenv.mkDerivation (finalAttrs: rec {
   };
 
   meta = with lib; {
-    changelog = "https://github.com/OSGeo/PROJ/blob/${src.rev}/NEWS";
+    changelog = "https://github.com/OSGeo/PROJ/blob/${finalAttrs.src.rev}/NEWS";
     description = "Cartographic Projections Library";
     homepage = "https://proj.org/";
     license = licenses.mit;

--- a/pkgs/proj/default.nix
+++ b/pkgs/proj/default.nix
@@ -45,6 +45,10 @@ stdenv.mkDerivation (finalAttrs: {
     "-DNLOHMANN_JSON_ORIGIN=external"
     "-DEXE_SQLITE3=${buildPackages.sqlite}/bin/sqlite3"
   ];
+  CXXFLAGS = [
+    # GCC 13: error: 'int64_t' in namespace 'std' does not name a type
+    "-include cstdint"
+  ];
 
   preCheck =
     let

--- a/pkgs/qgis/pdal-2_5.nix
+++ b/pkgs/qgis/pdal-2_5.nix
@@ -1,0 +1,131 @@
+{ lib
+, stdenv
+, callPackage
+, fetchFromGitHub
+, testers
+
+, enableE57 ? lib.meta.availableOn stdenv.hostPlatform libe57format
+
+, cmake
+, curl
+, gdal
+, hdf5-cpp
+, LASzip
+, libe57format
+, libgeotiff
+, libtiff
+, libxml2
+, openscenegraph
+, pkg-config
+, postgresql
+, tiledb
+, xercesc
+, zlib
+, zstd
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pdal";
+  version = "2.5.6";
+
+  src = fetchFromGitHub {
+    owner = "PDAL";
+    repo = "PDAL";
+    rev = finalAttrs.version;
+    sha256 = "sha256-JKwa89c05EfZ/FxOkj8lYmw0o2EgSqafRDIV2mTpZ5E=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs = [
+    curl
+    gdal
+    hdf5-cpp
+    LASzip
+    libgeotiff
+    libtiff
+    libxml2
+    openscenegraph
+    postgresql
+    tiledb
+    xercesc
+    zlib
+    zstd
+  ] ++ lib.optionals enableE57 [
+    libe57format
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_PLUGIN_E57=${if enableE57 then "ON" else "OFF"}"
+    "-DBUILD_PLUGIN_HDF=ON"
+    "-DBUILD_PLUGIN_PGPOINTCLOUD=ON"
+    "-DBUILD_PLUGIN_TILEDB=ON"
+    "-DWITH_TESTS=ON"
+    "-DBUILD_PGPOINTCLOUD_TESTS=OFF"
+
+    # Plugins can probably not be made work easily:
+    "-DBUILD_PLUGIN_CPD=OFF"
+    "-DBUILD_PLUGIN_FBX=OFF" # Autodesk FBX SDK is gratis+proprietary; not packaged in nixpkgs
+    "-DBUILD_PLUGIN_GEOWAVE=OFF"
+    "-DBUILD_PLUGIN_I3S=OFF"
+    "-DBUILD_PLUGIN_ICEBRIDGE=OFF"
+    "-DBUILD_PLUGIN_MATLAB=OFF"
+    "-DBUILD_PLUGIN_MBIO=OFF"
+    "-DBUILD_PLUGIN_MRSID=OFF"
+    "-DBUILD_PLUGIN_NITF=OFF"
+    "-DBUILD_PLUGIN_OCI=OFF"
+    "-DBUILD_PLUGIN_RDBLIB=OFF" # Riegl rdblib is proprietary; not packaged in nixpkgs
+    "-DBUILD_PLUGIN_RIVLIB=OFF"
+  ];
+
+  doCheck = true;
+
+  disabledTests = [
+    # Tests failing due to TileDB library implementation, disabled also
+    # by upstream CI.
+    # See: https://github.com/PDAL/PDAL/blob/bc46bc77f595add4a6d568a1ff923d7fe20f7e74/.github/workflows/linux.yml#L81
+    "pdal_io_tiledb_writer_test"
+    "pdal_io_tiledb_reader_test"
+    "pdal_io_tiledb_time_writer_test"
+    "pdal_io_tiledb_time_reader_test"
+    "pdal_io_tiledb_bit_fields_test"
+    "pdal_io_e57_read_test"
+    "pdal_io_e57_write_test"
+    "pdal_io_stac_reader_test"
+
+    # Segfault
+    "pdal_io_hdf_reader_test"
+
+    # Failure
+    "pdal_app_plugin_test"
+  ];
+
+  checkPhase = ''
+    runHook preCheck
+    # tests are flaky and they seem to fail less often when they don't run in
+    # parallel
+    ctest -j 1 --output-on-failure -E '^${lib.concatStringsSep "|" finalAttrs.disabledTests}$'
+    runHook postCheck
+  '';
+
+  passthru.tests = {
+    version = testers.testVersion {
+      package = finalAttrs.finalPackage;
+      command = "pdal --version";
+      version = "pdal ${finalAttrs.finalPackage.version}";
+    };
+    pkg-config = testers.testMetaPkgConfig finalAttrs.finalPackage;
+  };
+
+  meta = with lib; {
+    description = "PDAL is Point Data Abstraction Library. GDAL for point cloud data";
+    homepage = "https://pdal.io";
+    license = licenses.bsd3;
+    maintainers = teams.geospatial.members;
+    platforms = platforms.all;
+    pkgConfigModules = [ "pdal" ];
+  };
+})

--- a/pkgs/qgis/unwrapped-ltr.nix
+++ b/pkgs/qgis/unwrapped-ltr.nix
@@ -1,4 +1,5 @@
 { lib
+, callPackage
 , fetchFromGitHub
 , fetchpatch
 , makeWrapper
@@ -47,6 +48,10 @@
 }:
 
 let
+
+  # replace with global pdal version once
+  # https://github.com/qgis/QGIS/pull/54940 is backported
+  pdal = callPackage ./pdal-2_5.nix { };
 
   # pyqt5 override was moved to flake.nix
   py = python3;


### PR DESCRIPTION
- pkgs(pdal): 2.5.6 -> 2.6.2
- pkgs(qgis-ltr): build with pdal 2.5
- pkgs(gdal): 3.8.2 -> 3.8.3
- pkgs(postgis): build with minimal gdal version
- pkgs(proj): don't use rec with finalAttrs function
- pkgs(proj): fixup build with gcc13
