### PR TITLE
grass: enable opengl

### DIFF
--- a/pkgs/grass/default.nix
+++ b/pkgs/grass/default.nix
@@ -13,6 +13,7 @@
 , flex
 , gdal
 , geos
+, libGLU
 , libiconv
 , libmysqlclient
 , libpng
@@ -63,6 +64,7 @@ stdenv.mkDerivation (finalAttrs: {
     fftw
     gdal
     geos
+    libGLU
     libmysqlclient
     libpng
     libtiff
@@ -109,7 +111,7 @@ stdenv.mkDerivation (finalAttrs: {
     "--with-readline"
     "--with-wxwidgets"
     "--with-zstd"
-    "--without-opengl"
+    "--with-opengl"
   ] ++ lib.optionals stdenv.isLinux [
     "--with-pdal"
   ] ++ lib.optionals stdenv.isDarwin [


### PR DESCRIPTION
This PR enables OpenGL support for GRASS package. 

But unfortunately 3D view in GRASS GUI doesn't work:

```
./src/unix/glegl.cpp(391) in InitVisual(): Failed to get an
EGLConfig for the requested attributes.
```

![image](https://github.com/imincik/geospatial-nix/assets/5683186/d78871fe-ebb0-4da6-bea3-7551a05a1205)

This bug seems to be related to wxWidgets packaging. I tested the same version of wxWidget (3.4.2) and wxPython (4.2.1) in Nix and Debian. On Debian 3D view works as expected. So probably the problem could be related to wxWidgets packaging in Nix(?)